### PR TITLE
Updates for Go Scanner and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Barista allows a developer to set up their project for scanning from any Git com
     2. .Net using the NuGet package manager
     3. Node using the NPM package manager
     4. Python using the PIP package manager
-    - Support for additional package managers are on the roadmap as the community evolves e.g. Gradle, Go
+    5. GoLang using modules package manager
+    - Support for additional package managers are on the roadmap as the community evolves e.g. Gradle
 
 1.  Each technology stack uses native tools to gather project dependencies with as much meta data as can be harvested e.g. license, publisher information and or the project's published URL
 1. Unsupported technology stacks can be scanned using the [nexB/scancode-tool](https://github.com/nexB/scancode-toolkit) but results are not as comprehensive and performance is degraded.

--- a/barista-scan/src/default-scan/scanners/go-licenses/go-licenses.service.ts
+++ b/barista-scan/src/default-scan/scanners/go-licenses/go-licenses.service.ts
@@ -36,11 +36,7 @@ export class GoLicensesService extends ScannerBaseService {
       targetDir = path.join(jobInfo.tmpDir, scan.project.customPackageManagerPath);
     }
 
-    let binary = 'go-licenses';
-    // Get the platfrom specific go-licenses binary
-    if (process.platform === 'darwin') {
-      binary = 'mac-go-licenses';
-    }
+    const binary = 'go-licenses';
 
     // tslint:disable-next-line:max-line-length
     const command = `cd ${targetDir}; GOPATH=${targetDir}/.go ${binary} csv ./ > ${jobInfo.dataDir}/go-licenses.csv`;

--- a/barista-web/src/app/features/projects/project-details/project-details.component.ts
+++ b/barista-web/src/app/features/projects/project-details/project-details.component.ts
@@ -179,7 +179,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
 
     this.projectStatusTypeService.getAll();
     this.outputFormatTypeService.getAll();
-    this.packageManagerService.getAll();
+    this.packageManagerService.getWithQuery({ sort: 'description,ASC' });
     this.deploymentTypeService.getAll();
     this.projectDevelopmentTypeService.getAll();
 

--- a/doc/local-dev-environment.md
+++ b/doc/local-dev-environment.md
@@ -36,3 +36,6 @@ In order to execute project scans, the following software packages must be insta
   * `brew install maven`
 * Nuget (.NET project dependencies and licenses)
   * `brew install nuget`
+* GoLang (GoLang with modules support)
+  * `Go v1.13 or later installed`
+  * `go get github.com/google/go-licenses`


### PR DESCRIPTION
Sort Package Managers
Update Go-Licenses for local development to use installed version if Go-Licenses
Update Documentation to include Go Scanner and developer documentation