### PR TITLE
removes migration content update to mitigate errors when updating

### DIFF
--- a/barista-api/src/db/migrations/1593094810331-ProjectIDMigration.ts
+++ b/barista-api/src/db/migrations/1593094810331-ProjectIDMigration.ts
@@ -7,13 +7,13 @@ import {MigrationInterface, QueryRunner} from "typeorm";
 export class ProjectIDMigration1593094810331 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            "UPDATE tool_tip SET content='Input your ProjectID', element_name='projectID' WHERE element_name='askID'"
+            "UPDATE tool_tip SET element_name='projectID' WHERE element_name='askID'"
         );
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            "UPDATE tool_tip SET content='Input your askID', element_name='askID' WHERE element_name='projectID'"
+            "UPDATE tool_tip SET element_name='askID' WHERE element_name='projectID'"
         );
     }
 


### PR DESCRIPTION
previous change modified the content of the field as well, which could modify and revert a user's environment. This doesn't make that change so that existing databases remain intact.