### PR TITLE
disabled inputs based on information entered

### DIFF
--- a/barista-web/src/app/features/projects/project-details/project-details.component.html
+++ b/barista-web/src/app/features/projects/project-details/project-details.component.html
@@ -24,7 +24,10 @@
               </mat-form-field>
             </mat-grid-tile>
             <mat-grid-tile>
-              <mat-form-field class="field">
+              <mat-form-field class="field"
+              [matTooltipDisabled]="!project.pathToUploadFileForScanning ? '' : null"
+              [matTooltip]="tooltips['gitUrl']"
+              >
                 <input matInput placeholder="GitHub Repo"
                        url pattern="https?://.+"
                        [(ngModel)]="project.gitUrl"
@@ -96,11 +99,15 @@
 
 
             <mat-grid-tile>
-              <mat-form-field class="field">
+              <mat-form-field class="field" 
+              [matTooltip]="tooltips['pathToUploadFileForScanning']"
+              [matTooltipDisabled]="!project.gitUrl ? '' : null"
+              >
                 <input matInput placeholder="Path to upload file for scanning"
                        [(ngModel)]="project.pathToUploadFileForScanning" name="pathToUploadFileForScanning"
                        [matTooltip]="tooltips['pathToUploadFileForScanning']"
-                       [disabled]="project.gitUrl? '' : null">
+                       [disabled]="project.gitUrl? '' : null"
+                >
               </mat-form-field>
             </mat-grid-tile>
             <mat-grid-tile>

--- a/barista-web/src/app/features/projects/project-details/project-details.component.html
+++ b/barista-web/src/app/features/projects/project-details/project-details.component.html
@@ -30,7 +30,9 @@
                        [(ngModel)]="project.gitUrl"
                        name="gitUrl"
                        [attr.required]="project.developmentType && project.developmentType.code != 'community'"
-                       [matTooltip]="tooltips['gitUrl']">
+                       [matTooltip]="tooltips['gitUrl']"
+                       [disabled]="project.pathToUploadFileForScanning? '' : null"
+                       >
               </mat-form-field>
             </mat-grid-tile>
             <mat-grid-tile>
@@ -97,7 +99,8 @@
               <mat-form-field class="field">
                 <input matInput placeholder="Path to upload file for scanning"
                        [(ngModel)]="project.pathToUploadFileForScanning" name="pathToUploadFileForScanning"
-                       [matTooltip]="tooltips['pathToUploadFileForScanning']">
+                       [matTooltip]="tooltips['pathToUploadFileForScanning']"
+                       [disabled]="project.gitUrl? '' : null">
               </mat-form-field>
             </mat-grid-tile>
             <mat-grid-tile>


### PR DESCRIPTION
## Purpose:
disable GitHub Repo input if Path to upload file for scanning input is filled and vice versa.
## Type:
- [ ] Documentation:

- [ ] Bugfix:

- [x] New Feature: 

## Changes:
project-details.component.html