### PR TITLE
remove tags from scanbranch option

### DIFF
--- a/barista-api/src/controllers/project/project.controller.ts
+++ b/barista-api/src/controllers/project/project.controller.ts
@@ -232,12 +232,12 @@ export class ProjectController implements CrudController<Project> {
           scanBranchDto.branch = branchName;
           branchesAndTags.push(scanBranchDto);
         }
-        const tag = element.indexOf('refs/tags/');
-        const tagName = element.substring(tag + 12);
-        if (tag > 0) {
-          scanBranchDto.branch = tagName;
-          branchesAndTags.push(scanBranchDto);
-        }
+        // const tag = element.indexOf('refs/tags/');
+        // const tagName = element.substring(tag + 12);
+        // if (tag > 0) {
+        //   scanBranchDto.branch = tagName;
+        //   branchesAndTags.push(scanBranchDto);
+        // }
       });
       return branchesAndTags;
     }


### PR DESCRIPTION
## Purpose:
Remove displaying of Tags from Scan Branch Option
## Type:
- [ ] Documentation:

- [X] Bugfix:

- [ ] New Feature: 

## Changes:

Changed API option to return tags, only branches.

## Caveats:

Fixes #155 