### PR TITLE
changes 'Dashboard' button to 'Home' button

### DIFF
--- a/barista-web/src/app/shared/layout/header/header.component.html
+++ b/barista-web/src/app/shared/layout/header/header.component.html
@@ -4,7 +4,7 @@
     <img src="assets/images/barista_logo_coffee_left.png" width="100%">
   </button>
   <span class="fill-space"></span>
-  <button *ngIf="isLoggedIn" mat-button (click)="dashboardLink()" type="submit">Dashboard</button>
+  <button *ngIf="isLoggedIn" mat-button (click)="homeLink()" type="submit">Home</button>
   <button *ngIf="isLoggedIn" mat-button (click)="myProjectLink()" type="submit">Projects</button>
   <app-help-menu title="Help"></app-help-menu>
   <span *ngIf="isLoggedIn && isAdmin">


### PR DESCRIPTION
## Purpose:
Changes the 'Dashboard' button on the toolbar to be a 'Home' button

## Type:
- [ ] Documentation:

- [ ] Bugfix:

- [X] New Feature: 

## Changes:
* changes the 'Dashboard' button to be a 'Home' button
  - done for accessibility and clarity

Dashboard was confusing, as in some senses the Home page is the Dashboard. While we had a Home button in the logo on the toolbar, we felt a more clear button would help users to not be confused.

## Caveats:
n/a 

Fixes #173 