### PR TITLE
Add Dataset Buttons to Home

### DIFF
--- a/barista-web/src/app/features/home/home.component.html
+++ b/barista-web/src/app/features/home/home.component.html
@@ -18,27 +18,14 @@
         </div>
       </div>
       <div class="row" *ngIf="isLoggedIn" style="justify-content: center; align-items: center;">
-        <div class="button">
-          <a mat-raised-button (click)="changeDataset('personal')">
-            <span>
-              Personal
-            </span>
-          </a>
-        </div>
-        <div class="button"> 
-          <a mat-raised-button (click)="changeDataset('organization')">
-            <span>
-              Organization
-            </span>
-          </a>
-        </div>
-        <div class="button">
-          <a mat-raised-button (click)="changeDataset('community')">
-            <span>
-              Community
-            </span>
-          </a>
-        </div>
+        <mat-button-toggle-group>
+          <div class="button">
+            <mat-button-toggle (click)="changeDataset('my')" value="Personal"><span>Personal</span></mat-button-toggle>
+          </div>
+          <div class="button"> 
+            <mat-button-toggle (click)="changeDataset('organization')" value="Organization"><span>Organization</span></mat-button-toggle>
+          </div>
+        </mat-button-toggle-group>
       </div>
     </div>
     <!-- End of Banner -->

--- a/barista-web/src/app/features/home/home.component.html
+++ b/barista-web/src/app/features/home/home.component.html
@@ -1,19 +1,44 @@
 <div class="flex-grid" fxFlex>
   <div class="row">
     <!-- Banner -->
-    <div class="banner" *ngIf="!isLoggedIn">
-      <div class="image">
-        <img src="assets/images/barista_logo_text_removed.png">
+    <div class="banner">
+      <div *ngIf="!isLoggedIn">
+        <div class="image">
+          <img src="assets/images/barista_logo_text_removed.png">
+        </div>
+        <div class="mat-headline banner_text" style="text-align: center;">
+          Open Source Governance <br> Ensuring You Always Have a Great Brew
+        </div>
+        <div class="button">
+          <a mat-raised-button [href]="'https://optum.github.io/barista/'" target="_blank">
+            <span>
+              Learn More
+            </span>
+          </a>
+        </div>
       </div>
-      <div class="mat-headline banner_text" style="text-align: center;">
-        Open Source Governance <br> Ensuring You Always Have a Great Brew
-      </div>
-      <div class="button">
-        <a mat-raised-button [href]="'https://optum.github.io/barista/'" target="_blank">
-          <span>
-            Learn More
-          </span>
-        </a>
+      <div class="row" *ngIf="isLoggedIn" style="justify-content: center; align-items: center;">
+        <div class="button">
+          <a mat-raised-button (click)="changeDataset('personal')">
+            <span>
+              Personal
+            </span>
+          </a>
+        </div>
+        <div class="button"> 
+          <a mat-raised-button (click)="changeDataset('organization')">
+            <span>
+              Organization
+            </span>
+          </a>
+        </div>
+        <div class="button">
+          <a mat-raised-button (click)="changeDataset('community')">
+            <span>
+              Community
+            </span>
+          </a>
+        </div>
       </div>
     </div>
     <!-- End of Banner -->

--- a/barista-web/src/app/features/home/home.component.scss
+++ b/barista-web/src/app/features/home/home.component.scss
@@ -1,6 +1,7 @@
 @import 'variables';
 
 $page-padding: 30px;
+$column-margin: 15px;
 
 .flex-grid{
     justify-content: space-between;
@@ -24,7 +25,7 @@ $page-padding: 30px;
     min-width: 0; // allows shrinking & growing
     flex: 1 0 0;
     // 30px spacing between elements
-    margin: 15px;
+    margin: $column-margin;
 
     .mat-card {
         justify-content: center;
@@ -59,16 +60,26 @@ $page-padding: 30px;
     padding: 2%;
     text-align: center;
 
-    a {
+    mat-button-toggle {
         display: flex;
         background-color: $accent-color;
         justify-content: center;
         align-items: center;
         width: 15vw;
         height: 6vh;
-
+        margin-left: $column-margin;
+        margin-right: $column-margin;
+        margin-top: $column-margin;
+        border-radius: 5px;
         span {
             font-size: large;
+        }
+    }
+
+    .mat-button-toggle-checked {
+        color: #d0ac83;
+        span {
+            text-decoration: underline;
         }
     }
 }

--- a/barista-web/src/app/features/home/home.component.ts
+++ b/barista-web/src/app/features/home/home.component.ts
@@ -17,8 +17,10 @@ interface Threshold{
 export class HomeComponent implements OnInit {
   constructor(private statsApi: StatsApiService) {}
 
-  /* Data Variables */
   isLoggedIn: boolean;
+  dataset: string;
+
+  /* Data Variables */
   topComponentLicenseData: any;
   topComponentScansData: any;
   topVulnerabilities: any;
@@ -43,8 +45,9 @@ export class HomeComponent implements OnInit {
    */
   ngOnInit(): void {
     this.isLoggedIn = AuthService.isLoggedIn;
+    this.dataset = 'organization';
 
-    this.statsApi.statsComponentsGet('organization').subscribe((response) => {
+    this.statsApi.statsComponentsGet(this.dataset).subscribe((response) => {
       this.topComponentLicenseData = response;
     });
 
@@ -52,7 +55,7 @@ export class HomeComponent implements OnInit {
       this.topVulnerabilities = response;
     });
 
-    this.statsApi.statsComponentsScansGet('organization').subscribe((response) => {
+    this.statsApi.statsComponentsScansGet(this.dataset).subscribe((response) => {
       this.topComponentScansData = response;
     })
 
@@ -66,12 +69,12 @@ export class HomeComponent implements OnInit {
       this.monthlyProjectScans = response;
     })
 
-    this.statsApi.statsHighVulnerabilityGet('organization').subscribe((response) => {
+    this.statsApi.statsHighVulnerabilityGet(this.dataset).subscribe((response) => {
       var displayName = this.displaySeverity(response, this.vulnerabilityThreshold);
       this.highVulnerability = [{"name": displayName, "value": response}];
     })
 
-    this.statsApi.statsLicenseOnComplianceGet('organization').subscribe((response) => {
+    this.statsApi.statsLicenseOnComplianceGet(this.dataset).subscribe((response) => {
       var displayName = this.displaySeverity(response, this.licenseThreshold);
       this.licenseOnCompliance = [{"name": displayName, "value": response}];
     })
@@ -142,5 +145,10 @@ export class HomeComponent implements OnInit {
       }
 
       return data;
+    }
+
+    changeDataset(dataset: string){
+      this.dataset = dataset;
+      
     }
 }

--- a/barista-web/src/app/features/home/home.component.ts
+++ b/barista-web/src/app/features/home/home.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit } from '@angular/core';
-
+import { Component, OnInit, OnChanges } from '@angular/core';
 import { AuthService, AuthServiceStatus } from '@app/features/auth/auth.service';
 import { StatsApiService } from '@app/shared/api/api/stats-api.service';
 
@@ -14,7 +13,7 @@ interface Threshold{
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
 })
-export class HomeComponent implements OnInit {
+export class HomeComponent implements OnInit, OnChanges {
   constructor(private statsApi: StatsApiService) {}
 
   isLoggedIn: boolean;
@@ -44,8 +43,21 @@ export class HomeComponent implements OnInit {
    * Handles subscribing of data async's into data vars.
    */
   ngOnInit(): void {
-    this.isLoggedIn = AuthService.isLoggedIn;
     this.dataset = 'organization';
+    this.getDatasets();
+  }
+
+  ngOnChanges():void {
+    this.getDatasets();
+  }
+
+  changeDataset(dataset: string){
+    this.dataset = dataset;
+    this.ngOnChanges();
+  }
+
+  getDatasets(){
+    this.isLoggedIn = AuthService.isLoggedIn;
 
     this.statsApi.statsComponentsGet(this.dataset).subscribe((response) => {
       this.topComponentLicenseData = response;
@@ -79,76 +91,72 @@ export class HomeComponent implements OnInit {
       this.licenseOnCompliance = [{"name": displayName, "value": response}];
     })
   }
-    displaySeverity(n: any, t: Threshold){
-      if(n < t.low){ return 'LOW' }
-      else if(n < t.medium){ return 'MEDIUM' }
-      else if(n < t.high){ return 'HIGH' }
-      else { return 'CRITICAL' }
-    }
 
-    parseMonth(data: any){
-      for (var item of data){
-        switch (item.name.substring(5, 7)) {
-          case "01": {
-            item.name = "Jan" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          case "02": {
-            item.name = "Feb" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          case "03": {
-            item.name = "Mar" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          case "04": {
-            item.name = "Apr" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          case "05": {
-            item.name = "May" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          case "06": {
-            item.name = "Jun" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          case "07": {
-            item.name = "Jul" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          case "08": {
-            item.name = "Aug" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          case "09": {
-            item.name = "Sep" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          case "10": {
-            item.name = "Oct" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          case "11": {
-            item.name = "Nov" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          case "12": {
-            item.name = "Dec" + " '" + item.name.substring(2, 4);
-            break;
-          }
-          default: {
-            item.name = "Unknown" + " '" + item.name.substring(2, 4);
-            break;
-          }
+  displaySeverity(n: any, t: Threshold){
+    if(n < t.low){ return 'LOW' }
+    else if(n < t.medium){ return 'MEDIUM' }
+    else if(n < t.high){ return 'HIGH' }
+    else { return 'CRITICAL' }
+  }
+
+  parseMonth(data: any){
+    for (var item of data){
+      switch (item.name.substring(5, 7)) {
+        case "01": {
+          item.name = "Jan" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        case "02": {
+          item.name = "Feb" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        case "03": {
+          item.name = "Mar" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        case "04": {
+          item.name = "Apr" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        case "05": {
+          item.name = "May" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        case "06": {
+          item.name = "Jun" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        case "07": {
+          item.name = "Jul" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        case "08": {
+          item.name = "Aug" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        case "09": {
+          item.name = "Sep" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        case "10": {
+          item.name = "Oct" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        case "11": {
+          item.name = "Nov" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        case "12": {
+          item.name = "Dec" + " '" + item.name.substring(2, 4);
+          break;
+        }
+        default: {
+          item.name = "Unknown" + " '" + item.name.substring(2, 4);
+          break;
         }
       }
-
-      return data;
     }
 
-    changeDataset(dataset: string){
-      this.dataset = dataset;
-      
-    }
+    return data;
+  }
 }


### PR DESCRIPTION
## Purpose:
To add toggle-able buttons to the home page to switch between personal and organization datasets. 

## Type:
- [ ] Documentation:

- [ ] Bugfix:

- [X] New Feature: 

## Changes:
* Adds buttons that appear on sign in
* Button text is underlined and its color is changed on select
* On select, the dataset is changed and re-rendered in the charts
* Only updates the charts, not the entire page

## Caveats:
Restricted to one page with no external routing. Dependent on using the buttons to switch datasets, some users may just want a hyperlink to a webpage, but that is not implemented currently. In theory, that could be done, but we felt it wouldn't be necessary for this version of the page.

Fixes #184 