### PR TITLE
Added SQL parameter capabilities

### DIFF
--- a/barista-web/src/app/features/home/home.component.ts
+++ b/barista-web/src/app/features/home/home.component.ts
@@ -48,7 +48,7 @@ export class HomeComponent implements OnInit {
       this.topComponentLicenseData = response;
     });
 
-    this.statsApi.statsVulnerabilitiesGet().subscribe((response) => {
+    this.statsApi.statsVulnerabilitiesGet('organization').subscribe((response) => {
       this.topVulnerabilities = response;
     });
 
@@ -56,12 +56,12 @@ export class HomeComponent implements OnInit {
       this.topComponentScansData = response;
     })
 
-    this.statsApi.statsProjectsGet().subscribe((response) => {
+    this.statsApi.statsProjectsGet('organization').subscribe((response) => {
       response = this.parseMonth(response);
       this.projectsAddedMonthly = response;
     })
 
-    this.statsApi.statsProjectsScansGet().subscribe((response) => {
+    this.statsApi.statsProjectsScansGet('organization').subscribe((response) => {
       response = this.parseMonth(response);
       this.monthlyProjectScans = response;
     })

--- a/barista-web/src/app/shared/api/api/stats-api.service.ts
+++ b/barista-web/src/app/shared/api/api/stats-api.service.ts
@@ -83,7 +83,7 @@ export class StatsApiService {
         );
     }
 
-    public statsVulnerabilitiesGet(fields?: string, join?: string, cache?: number, observe?: 'body', reportProgress?: boolean): Observable<Array<ChartElementDto>> {
+    public statsVulnerabilitiesGet(dev_type: string, fields?: string, join?: string, cache?: number, observe?: 'body', reportProgress?: boolean): Observable<Array<ChartElementDto>> {
         let queryParameters = new HttpParams({encoder: this.encoder});
         if (fields !== undefined && fields !== null) {
             queryParameters = queryParameters.set('fields', <any>fields);
@@ -106,7 +106,7 @@ export class StatsApiService {
         }
 
 
-        return this.httpClient.get<Array<ChartElementDto>>(`${this.configuration.basePath}/stats/vulnerabilities`,
+        return this.httpClient.get<Array<ChartElementDto>>(`${this.configuration.basePath}/stats/vulnerabilities/${dev_type}`,
             {
                 params: queryParameters,
                 withCredentials: this.configuration.withCredentials,
@@ -151,7 +151,7 @@ export class StatsApiService {
         );
     }
 
-    public statsProjectsGet(fields?: string, join?: string, cache?: number, observe?: 'body', reportProgress?: boolean): Observable<Array<ChartElementDto>> {
+    public statsProjectsGet(dev_type: string, fields?: string, join?: string, cache?: number, observe?: 'body', reportProgress?: boolean): Observable<Array<ChartElementDto>> {
 
 
         let queryParameters = new HttpParams({encoder: this.encoder});
@@ -177,7 +177,7 @@ export class StatsApiService {
         }
 
 
-        return this.httpClient.get<Array<ChartElementDto>>(`${this.configuration.basePath}/stats/projects`,
+        return this.httpClient.get<Array<ChartElementDto>>(`${this.configuration.basePath}/stats/projects/${dev_type}`,
             {
                 params: queryParameters,
                 withCredentials: this.configuration.withCredentials,
@@ -188,7 +188,7 @@ export class StatsApiService {
         );
     }
 
-    public statsProjectsScansGet(fields?: string, join?: string, cache?: number, observe?: 'body', reportProgress?: boolean): Observable<Array<ChartElementDto>> {
+    public statsProjectsScansGet(dev_type: string, fields?: string, join?: string, cache?: number, observe?: 'body', reportProgress?: boolean): Observable<Array<ChartElementDto>> {
 
 
         let queryParameters = new HttpParams({encoder: this.encoder});
@@ -214,7 +214,7 @@ export class StatsApiService {
         }
 
 
-        return this.httpClient.get<Array<ChartElementDto>>(`${this.configuration.basePath}/stats/projects/scans`,
+        return this.httpClient.get<Array<ChartElementDto>>(`${this.configuration.basePath}/stats/projects/scans/${dev_type}`,
             {
                 params: queryParameters,
                 withCredentials: this.configuration.withCredentials,


### PR DESCRIPTION
Modified SQL statements in stats.controller.ts so they will filter by development_type_code as the other SQL statements do

## Purpose:
Can now filter all of our chart datasets based on what dev type code is selecrted
## Type:
- [ ] New Feature: 
Additional SQL filtering
## Changes:
Changes made to SQL in stats.controller.ts and modifications made to stats-api.service.ts and home.component.ts to support these changes