### PR TITLE
Feature/user data fix

### DIFF
--- a/barista-web/src/app/features/home/banner/banner.component.ts
+++ b/barista-web/src/app/features/home/banner/banner.component.ts
@@ -21,11 +21,11 @@ import { UserInfo } from '@app/shared/api/model/user-info';
       </div>
     </div>
     <div *ngIf="isLoggedIn" class="row button-toggle">
-      <mat-button-toggle-group value="Organization">
+      <mat-button-toggle-group value="User">
         <div class="button">
           <mat-button-toggle (click)="changeDataset()" value="User" style="margin-right: 5px;"><span>User</span></mat-button-toggle>
         </div>
-        <div class="button"> 
+        <div class="button">
           <mat-button-toggle (click)="changeDataset('%')" value="Organization" style="margin-left: 5px;"><span>Organization</span></mat-button-toggle>
         </div>
       </mat-button-toggle-group>
@@ -41,7 +41,7 @@ export class BannerComponent implements OnInit {
   @Output() changeDatasetEvent = new EventEmitter<string>();
 
   constructor(private userApi: UserApiService) { this.dataset = ''; }
-  ngOnInit(): void { 
+  ngOnInit(): void {
     if(this.isLoggedIn){
       // pass through userID
       this.userApi.userMeGet().subscribe((response) => {

--- a/barista-web/src/app/features/home/home.component.ts
+++ b/barista-web/src/app/features/home/home.component.ts
@@ -50,7 +50,6 @@ export class HomeComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     this.isLoggedIn = AuthService.isLoggedIn;
     const { userInfo } = this.authService;
-    console.log(userInfo.id)
     this.initializeLoads();
     this.isLoggedIn ? this.dataset = userInfo.id : this.dataset = '%';
     this.getDatasets();

--- a/barista-web/src/app/features/home/home.component.ts
+++ b/barista-web/src/app/features/home/home.component.ts
@@ -10,7 +10,7 @@ import { Threshold } from '@app/shared/interfaces/Threshold';
   encapsulation: ViewEncapsulation.None,
 })
 export class HomeComponent implements OnInit, OnChanges {
-  constructor(private statsApi: StatsApiService, ) {}
+  constructor(private statsApi: StatsApiService, private authService: AuthService) {}
 
   isLoggedIn: boolean;
   dataset: string;
@@ -23,7 +23,7 @@ export class HomeComponent implements OnInit, OnChanges {
   isLoadingStatsProjectsScans: boolean;
   isLoadingStatsHighVulnerability: boolean;
   isLoadingStatsLicenseNonCompliance: boolean;
-  
+
   /* Data Variables */
   topComponentLicenseData: any;
   topComponentScansData: any;
@@ -48,8 +48,11 @@ export class HomeComponent implements OnInit, OnChanges {
    * Handles subscribing of data async's into data vars.
    */
   ngOnInit(): void {
+    this.isLoggedIn = AuthService.isLoggedIn;
+    const { userInfo } = this.authService;
+    console.log(userInfo.id)
     this.initializeLoads();
-    this.dataset = '%';
+    this.isLoggedIn ? this.dataset = userInfo.id : this.dataset = '%';
     this.getDatasets();
   }
 
@@ -59,12 +62,12 @@ export class HomeComponent implements OnInit, OnChanges {
   }
 
   initializeLoads(){
-    this.isLoadingStatsComponent = true; 
-    this.isLoadingStatsVulnerabilities = true; 
-    this.isLoadingStatsComponentsScans = true; 
-    this.isLoadingStatsProjects = true; 
-    this.isLoadingStatsProjectsScans = true; 
-    this.isLoadingStatsHighVulnerability = true; 
+    this.isLoadingStatsComponent = true;
+    this.isLoadingStatsVulnerabilities = true;
+    this.isLoadingStatsComponentsScans = true;
+    this.isLoadingStatsProjects = true;
+    this.isLoadingStatsProjectsScans = true;
+    this.isLoadingStatsHighVulnerability = true;
     this.isLoadingStatsLicenseNonCompliance = true;
   }
 
@@ -74,8 +77,7 @@ export class HomeComponent implements OnInit, OnChanges {
   }
 
   getDatasets(){
-    this.isLoggedIn = AuthService.isLoggedIn;
-    
+
     this.statsApi.statsHighVulnerabilityGet(this.dataset).subscribe((response) => {
       var displayName = this.displaySeverity(response, this.vulnerabilityThreshold);
       if (Number(response) == -1){

--- a/barista-web/src/app/shared/layout/header/header.component.html
+++ b/barista-web/src/app/shared/layout/header/header.component.html
@@ -1,8 +1,6 @@
 <div>
   <mat-toolbar color="primary">
-    <button class="logo" mat-button (click)="homeLink()" title="Home">
-      <img src="assets/images/barista_logo_coffee_left.png" width="100%" />
-    </button>
+      <img class="logo" src="assets/images/barista_logo_coffee_left.png" width="100%" />
     <span class="fill-space"></span>
     <button *ngIf="isLoggedIn" mat-button (click)="homeLink()" type="submit" [class.clicked]="onHome && !menuClicked">
       <mat-icon class="routeIcon">home</mat-icon>

--- a/barista-web/src/app/shared/layout/header/header.component.ts
+++ b/barista-web/src/app/shared/layout/header/header.component.ts
@@ -96,7 +96,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
   async homeLink() {
     await this.router.navigate(['/home']);
-    window.location.reload();
   }
   profileBtn() {
     this.isVisible = true;


### PR DESCRIPTION
## Purpose:
Dashboard is initialized with User data after sign in

## Type:
- [ ] Documentation:

- [ ] Bugfix:

- [X] New Feature: 
Sets default dataset for the dashboard to be based on user id once logged in

## Changes:
*Gets user info upon initialization and sets dataset to user id if the user is logged in
*Removes page refresh when navigating to home page

## Caveats:
*When the user has not signed in before, or when no user info is available, an error in the console will occur when trying to pull user info. However, this doesn't impact this feature's functionality. This can be replicated in an incognito browser window. 
