### PR TITLE
Prevent configuration loading from canceling request

### DIFF
--- a/barista-web/src/app/shared/helpers/managehttp.interceptor.ts
+++ b/barista-web/src/app/shared/helpers/managehttp.interceptor.ts
@@ -18,6 +18,9 @@ export class ManageHttpInterceptor implements HttpInterceptor {
   }
 
   intercept<T>(req: HttpRequest<T>, next: HttpHandler): Observable<HttpEvent<T>> {
+    if (req.url.toString().includes('api/v1/system-configuration')) {
+      return next.handle(req);
+    }
     return next.handle(req).pipe(takeUntil(this.httpCancelService.onCancelPendingRequests()));
   }
 }


### PR DESCRIPTION
## Purpose:
Prevent configuration loading from canceling request
## Type:
- [ ] Documentation:

- [X] Bugfix:

- [ ] New Feature: 

## Changes:

* Add setting to HTTP interceptor to skip cancel request when system configuration API call

## Caveats:

Hard code setting is not desirable.  Should add setting to whitelist setting in the future.