### PR TITLE
add wildcard route to catch bad routes

### DIFF
--- a/barista-web/src/app/app-routing.module.ts
+++ b/barista-web/src/app/app-routing.module.ts
@@ -28,6 +28,7 @@ const routes: Routes = [
     component: HomeComponent,
     data: { showHeader: true, showSidebar: false, showFooter: true },
   },
+  { path: '**', redirectTo: '/home', pathMatch: 'full' }
 ];
 
 @NgModule({


### PR DESCRIPTION
## Purpose:

If a user enters a bad link that looks like a possible link such as <https://barista.optum.com/asfsad> then the user will be directed to <https://barista.optum.com> which is an empty page. I have added a wildcard route to prevent that.

## Type:
- [ ] Documentation:

- [x] Bugfix:

- [ ] New Feature: 

## Changes:

Added a wildcard route to the top-level router in `barista-web`

## Caveats:

Fixes #156 