### PR TITLE
Update docusaurus.config.js

### DIFF
--- a/doc/barista-docs/docusaurus.config.js
+++ b/doc/barista-docs/docusaurus.config.js
@@ -97,7 +97,7 @@ module.exports = {
           items: [
             {
               label: 'barista-web',
-              href: 'https://raw.githubusercontent.com/Optum/barista/blob/master/barista-web/barista-web-attribution.txt',
+              href: 'https://raw.githubusercontent.com/Optum/barista/master/barista-web/barista-web-attribution.txt',
             },
             {
               label: 'barista-api',


### PR DESCRIPTION
fix typo - need to remove `blob` from URL

## Type:
- [ ] Documentation:

- [x] Bugfix:

- [ ] New Feature: 

