### PR TITLE
Add project-only API endpoint to stats controller

### DIFF
--- a/barista-api/package.json
+++ b/barista-api/package.json
@@ -90,7 +90,7 @@
     "convert-to-object": "^0.0.4",
     "csv-parse": "^4.6.3",
     "dotenv": "^8.0.0",
-    "elastic-apm-node": "^3.2.0",
+    "elastic-apm-node": "^3.10.0",
     "lodash": "^4.17.20",
     "module-alias": "^2.2.0",
     "nest-bull": "^0.9.0",

--- a/barista-api/src/controllers/stats/stats.controller.ts
+++ b/barista-api/src/controllers/stats/stats.controller.ts
@@ -76,7 +76,7 @@ export class StatsController implements CrudController<Project> {
   }
 
   @UseInterceptors(CrudRequestInterceptor)
-  @Get('/projects/minimum')
+  @Get('/project-only')
   async getprojectminimum(@ParsedRequest() req: CrudRequest) {
     return (await this.base.getManyBase(req)) as Project[];
   }

--- a/barista-api/src/controllers/stats/stats.controller.ts
+++ b/barista-api/src/controllers/stats/stats.controller.ts
@@ -21,6 +21,7 @@ import {
 } from '@nestjs/common';
 import { ApiUseTags, ApiResponse, ApiImplicitQuery } from '@nestjs/swagger';
 import { Response } from 'express';
+import { Swagger } from '@nestjsx/crud/lib/crud';
 
 import {
   Crud,
@@ -46,7 +47,11 @@ import { makeBadge, ValidationError } from 'badge-maker';
 @ApiUseTags('Stats')
 @Controller('stats')
 export class StatsController implements CrudController<Project> {
-  constructor(public service: ProjectService, private licenseScanResultItemService: LicenseScanResultItemService) {}
+  constructor(public service: ProjectService, private licenseScanResultItemService: LicenseScanResultItemService) {
+    const metadata = Swagger.getParams(this.getprojectminimum);
+    const queryParamsMeta = Swagger.createQueryParamsMeta('getManyBase');
+    Swagger.setParams([...metadata, ...queryParamsMeta], this.getprojectminimum);
+  }
   get base(): CrudController<Project> {
     return this;
   }
@@ -68,6 +73,18 @@ export class StatsController implements CrudController<Project> {
       }
     }
     return answer;
+  }
+
+  @UseInterceptors(CrudRequestInterceptor)
+  @Get('/projects/minimum')
+  async getprojectminimum(@ParsedRequest() req: CrudRequest) {
+    return (await this.base.getManyBase(req)) as Project[];
+  }
+
+  @UseInterceptors(CrudRequestInterceptor)
+  @Get('/export/list.xlsx')
+  async exportSome(@ParsedRequest() req: CrudRequest) {
+    // some awesome feature handling
   }
 
   createFormat(label: string, value: string, status: string) {

--- a/barista-api/src/controllers/stats/stats.controller.ts
+++ b/barista-api/src/controllers/stats/stats.controller.ts
@@ -81,12 +81,6 @@ export class StatsController implements CrudController<Project> {
     return (await this.base.getManyBase(req)) as Project[];
   }
 
-  @UseInterceptors(CrudRequestInterceptor)
-  @Get('/export/list.xlsx')
-  async exportSome(@ParsedRequest() req: CrudRequest) {
-    // some awesome feature handling
-  }
-
   createFormat(label: string, value: string, status: string) {
     let color = status;
     if (status === 'unknown') {

--- a/barista-api/src/controllers/stats/stats.controller.ts
+++ b/barista-api/src/controllers/stats/stats.controller.ts
@@ -48,9 +48,9 @@ import { makeBadge, ValidationError } from 'badge-maker';
 @Controller('stats')
 export class StatsController implements CrudController<Project> {
   constructor(public service: ProjectService, private licenseScanResultItemService: LicenseScanResultItemService) {
-    const metadata = Swagger.getParams(this.getprojectminimum);
+    const metadata = Swagger.getParams(this.getprojectonly);
     const queryParamsMeta = Swagger.createQueryParamsMeta('getManyBase');
-    Swagger.setParams([...metadata, ...queryParamsMeta], this.getprojectminimum);
+    Swagger.setParams([...metadata, ...queryParamsMeta], this.getprojectonly);
   }
   get base(): CrudController<Project> {
     return this;
@@ -77,7 +77,7 @@ export class StatsController implements CrudController<Project> {
 
   @UseInterceptors(CrudRequestInterceptor)
   @Get('/project-only')
-  async getprojectminimum(@ParsedRequest() req: CrudRequest) {
+  async getprojectonly(@ParsedRequest() req: CrudRequest) {
     return (await this.base.getManyBase(req)) as Project[];
   }
 


### PR DESCRIPTION
## Purpose:
Add project-only API endpoint to stats controller
## Type:
- [ ] Documentation:

- [ ] Bugfix:

- [X] New Feature: 

## Changes:
Add project-only API endpoint to stats controller